### PR TITLE
Chromedriver takes arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,17 +438,10 @@ var ChromeDriver = {
       this.reporterEvents.emit('report:log:system', 'dalek-browser-chrome: Switching to user defined port(s): ' + this.port + ' -> ' + this.maxPort);
     }
 
-   * Process user defined arguments
-   *
-   * @method _checkUserDefinedArgs
-   * @param {object} browser Browser configuration
-   */
-
-  _checkUserDefinedArgs: function (browser) {
     // check for a single defined port
     if (browser.chrome && browser.chrome.args && browser.chrome.args instanceof Array) {
-        this.userArgs = browser.chrome.args;
-        this.reporterEvents.emit('report:log:system', 'dalek-browser-chrome: Adding user defined arguements: ' + this.userArgs.join(' '));
+      this.userArgs = browser.chrome.args;
+      this.reporterEvents.emit('report:log:system', 'dalek-browser-chrome: Adding user defined arguements: ' + this.userArgs.join(' '));
     }
 
     return this;


### PR DESCRIPTION
This topic branch allows dalek-browser-chrome to pass any arguments to the chromedriver. 
- Removed _checkUserDefinedPorts 
- Replaced it with _checkUserDefinedArgs 
  - This checks for any arguments sent to the chrome driver, the ports and any normal arguments 

Thanks,

DanC

ps. I'm new to contributing to public repos, so apologies if I've missed some etiquette or the code is a bit squiffy. But git versioning is Wibbly wobbly Timey wimey, so I can re-do it!
