### PR TITLE
Added Chromedriver error log when Dalek can’t launch Chromedriver

### DIFF
--- a/index.js
+++ b/index.js
@@ -521,6 +521,7 @@ var ChromeDriver = {
     if (dataStr.search('DVFreeThread') === -1) {
       timeout = setTimeout(function () {
         deferred.reject();
+        this.reporterEvents.emit('error', 'Chromedriver: ' + dataStr.trim());
         this.reporterEvents.emit('error', 'dalek-driver-chrome: Could not launch Chromedriver');
         process.exit(127);
       }.bind(this), 2000);


### PR DESCRIPTION
This improves the error message to help diagnose problems like issue #15

before:

```
>> ERROR: dalek-driver-chrome: Could not launch Chromedriver
```

after:

```
>> ERROR: Chromedriver: Port not available. Exiting...
>> ERROR: dalek-driver-chrome: Could not launch Chromedriver
```
